### PR TITLE
Fix firefox - fails silently on bad mime type

### DIFF
--- a/broadcast.js
+++ b/broadcast.js
@@ -7,6 +7,7 @@ var hypercore = require('hypercore')
 var ram = require('random-access-memory')
 var pump = require('pump')
 var cluster = require('webm-cluster-stream')
+var mimeType = require('./lib/getMimeType')(window.MediaRecorder.isTypeSupported)
 
 module.exports = broadcast
 
@@ -38,7 +39,7 @@ function broadcast (state, emit) {
       el_preview.srcObject = stream
 
       var mediaRecorder = recorder(stream, {
-          mimeType: 'video/webm;codecs=vp9,opus',
+          mimeType: mimeType,
           videoBitsPerSecond: 200000,
           audioBitsPerSecond: 32000
       })

--- a/lib/getMimeType.js
+++ b/lib/getMimeType.js
@@ -1,0 +1,11 @@
+var MIME_TYPES = ['video/webm;codecs=vp9,opus', 'video/webm;codecs=vp8,opus']
+
+function getMimeType (supportFn) {
+  return MIME_TYPES.map(function (e) {
+    return supportFn(e) ? e : null
+  }).filter(function (e) {
+    return e !== null
+  })[0]
+}
+
+module.exports = getMimeType

--- a/watch.js
+++ b/watch.js
@@ -4,6 +4,7 @@ var swarm = require('webrtc-swarm')
 var hypercore = require('hypercore')
 var ram = require('random-access-memory')
 var pump = require('pump')
+var mimeType = require('./lib/getMimeType')(window.MediaSource.isTypeSupported)
 
 module.exports = watch
 
@@ -36,7 +37,7 @@ function watch (state, emit) {
   }
 
   function open () {
-    var sourceBuffer = mediaSource.addSourceBuffer('video/webm;codecs=vp9,opus')
+    var sourceBuffer = mediaSource.addSourceBuffer(mimeType)
 
     var hash = document.getElementById('key-input').value
     var feed = hypercore(ram, hash, {sparse: true})


### PR DESCRIPTION
Now FF is working. Though as you said on twitter I experienced bad behavior using FF and an http-based signaling server.
I can propose a patch to use https://github.com/soyuka/signalhubws. lmk